### PR TITLE
More tweaks to the simulation code

### DIFF
--- a/sim/__init__.py
+++ b/sim/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
 
-__all__ = ["wave2d"]
-
 from . import wave2d
+
+__all__ = ["wave2d"]

--- a/sim/wave2d/__init__.py
+++ b/sim/wave2d/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import
+
+from . wave2d import *
+
+__all__ = []
+__all__ += wave2d.__all__

--- a/sim/wave2d/wave2d.py
+++ b/sim/wave2d/wave2d.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 Simulates a wave
 """
 
+__all__ = ["simulate","simulate_raw","transform","add_noise"]
+
 __authors__ = ["Albert Shih"]
 __email__ = "albert.y.shih@nasa.gov"
 

--- a/test_wave2d.py
+++ b/test_wave2d.py
@@ -26,7 +26,7 @@ params = {
     
     #Noise parameters
     "noise_type": "Poisson", #can be None, "Normal", or "Poisson"
-    "noise_scale": 0.2,
+    "noise_scale": 0.3,
     "noise_mean": 1.,
     "noise_sdev": 1.,
     
@@ -49,6 +49,6 @@ params = {
     "hpcy_bin": 2.
 }
 
-#wave_maps = wave2d.simulate(params)
-wave_maps = wave2d.simulate(params, verbose = True)
+wave_maps = wave2d.simulate(params)
+#wave_maps = wave2d.simulate(params, verbose = True)
 visualize(wave_maps)

--- a/test_wave2d.py
+++ b/test_wave2d.py
@@ -1,6 +1,8 @@
 from sim import wave2d
 from visualize import visualize
 
+m2deg = 360./(2*3.1415926*6.96e8)
+
 params = {
     "cadence": 12., #seconds
     
@@ -10,7 +12,7 @@ params = {
     #Wave parameters that are initial conditions
     "direction": 25., #degrees, measured CCW from HG +latitude
     "epi_lat": 30., #degrees, HG latitude of wave epicenter
-    "epi_lon": 20., #degrees, HG longitude of wave epicenter
+    "epi_lon": 45., #degrees, HG longitude of wave epicenter
     
     #Wave parameters that can evolve over time
     #The first element is constant in time
@@ -18,25 +20,25 @@ params = {
     #The third element (if present) is quadratic in time
     #Be very careful of non-physical behavior
     "width": [90., 1.5], #degrees, full angle in azimuth, centered at 'direction'
-    "wave_thickness": [0.5, 0.02, -0.00005], #degrees, sigma of Gaussian profile in longitudinal direction
+    "wave_thickness": [6.0e6*m2deg,6.0e4*m2deg], #degrees, sigma of Gaussian profile in longitudinal direction
     "wave_normalization": [1.], #integrated value of the 1D Gaussian profile
-    "speed": [0.2, 0.002], #degrees/s, make sure that wave propagates all the way to lat_min for polynomial speed
+    "speed": [9.33e5*m2deg, -1.495e3*m2deg], #degrees/s, make sure that wave propagates all the way to lat_min for polynomial speed
     
     #Noise parameters
     "noise_type": "Poisson", #can be None, "Normal", or "Poisson"
-    "noise_scale": 0.05,
+    "noise_scale": 0.2,
     "noise_mean": 1.,
     "noise_sdev": 1.,
     
-    "max_steps": 50,
+    "max_steps": 20,
     
     #HG grid, probably would only want to change the bin sizes
     "lat_min": -90.,
     "lat_max": 90.,
-    "lat_bin": 1.,
+    "lat_bin": 0.2,
     "lon_min": -180.,
     "lon_max": 180.,
-    "lon_bin": 1.,
+    "lon_bin": 5.,
     
     #HPC grid, probably would only want to change the bin sizes
     "hpcx_min": -1000.,

--- a/test_wave2d.py
+++ b/test_wave2d.py
@@ -41,14 +41,14 @@ params = {
     "lon_bin": 5.,
     
     #HPC grid, probably would only want to change the bin sizes
-    "hpcx_min": -1000.,
-    "hpcx_max": 1000.,
-    "hpcx_bin": 10.,
-    "hpcy_min": -1000.,
-    "hpcy_max": 1000.,
-    "hpcy_bin": 10.
+    "hpcx_min": -1025.,
+    "hpcx_max": 1023.,
+    "hpcx_bin": 2.,
+    "hpcy_min": -1025.,
+    "hpcy_max": 1023.,
+    "hpcy_bin": 2.
 }
 
-wave_maps = wave2d.simulate(params)
-#wave_maps = wave2d.simulate(params, verbose = True)
+#wave_maps = wave2d.simulate(params)
+wave_maps = wave2d.simulate(params, verbose = True)
 visualize(wave_maps)


### PR DESCRIPTION
The test script now uses more physical wave parameters.  However, to get "proper" AIA-like images, the output bin sizes need to be smaller, but that explodes the simulation time.  (I take this back; see below.)  It is possible to restrict the output ranges (i.e., a submap) to slightly mitigate the effect.
