### PR TITLE
Bug fixes to util, and added more capability to sim.wave2d

### DIFF
--- a/test_wave2d.py
+++ b/test_wave2d.py
@@ -24,13 +24,21 @@ params = {
     "wave_normalization": [1.], #integrated value of the 1D Gaussian profile
     "speed": [9.33e5*m2deg, -1.495e3*m2deg], #degrees/s, make sure that wave propagates all the way to lat_min for polynomial speed
     
-    #Noise parameters
+    #Random noise parameters
     "noise_type": "Poisson", #can be None, "Normal", or "Poisson"
     "noise_scale": 0.1,
     "noise_mean": 1.,
     "noise_sdev": 1.,
     
+    #Structured noise parameters
+    "struct_type": None, #can be None, "Arcs", or "Random"
+    "struct_scale": 5.,
+    "struct_num": 10,
+    "struct_seed": 13092,
+    
     "max_steps": 20,
+    
+    "clean_nans": True,
     
     #HG grid, probably would only want to change the bin sizes
     "lat_min": -90.,
@@ -49,10 +57,20 @@ params = {
     "hpcy_bin": 2.4
 }
 
-wave_maps = wave2d.simulate(params)
-#wave_maps = wave2d.simulate(params, verbose = True)
+#wave_maps = wave2d.simulate(params)
+wave_maps = wave2d.simulate(params, verbose = True)
 
 #To get simulated HG' maps (centered at wave epicenter):
 #wave_maps_raw = wave2d.simulate_raw(params)
+#wave_maps_raw_noise = wave2d.add_noise(params, wave_maps_raw)
 
 visualize(wave_maps)
+
+
+#import util
+
+#new_wave_maps = []
+
+#for wave in wave_maps:
+#    print("Unraveling map at "+str(wave.date))
+#    new_wave_maps += [util.map_hpc_to_hg_rotate(wave, epi_lon = 45., epi_lat = 30., xbin = 5, ybin = 0.2)]

--- a/util.py
+++ b/util.py
@@ -1,9 +1,9 @@
 import sunpy
-from sunpy.wcs  import wcs as wcs
+from sunpy import wcs
 from scipy.interpolate import griddata
 import numpy as np
-from sim.wave2d.wave2d import euler_zyz
-from matplotlib import colors
+#from sim.wave2d.wave2d import euler_zyz
+#from matplotlib import colors
 
 __authors__ = ["Steven Christe"]
 __email__ = "steven.d.christe@nasa.gov"
@@ -34,7 +34,7 @@ def map_hpc_to_hg(map, xbin = 1, ybin = 1):
 
     newdata = griddata(points, values, newgrid, method="cubic")
 
-    header = map.header
+    header = map.header.copy()
     header['CDELT1'] = lon_bin
     header['NAXIS1'] = len(lon)
     header['CRVAL1'] = lon.min()
@@ -80,7 +80,7 @@ def map_hg_to_hpc(map, xbin = 10, ybin = 10):
     newdata = griddata(points, values, newgrid, method="linear")
     
     # now grab the original map header and update it
-    header = map.header
+    header = map.header.copy()
     header["CDELT1"] = xbin
     header["NAXIS1"] = len(x)
     header["CRVAL1"] = x.min()
@@ -110,22 +110,22 @@ def map_hg_to_hpc(map, xbin = 10, ybin = 10):
 def map_hpc_to_hg_rotate(map, epi_lon = 0, epi_lat = 0, xbin = 1, ybin = 1):
     """Take a map (like an AIA map) and convert it from HPC to HG."""
 
-    import sunpy
-    import util
-    from sunpy.wcs import wcs
-    import numpy as np
-    from scipy.interpolate import griddata
+    #import sunpy
+    #import util
+    #from sunpy import wcs
+    #import numpy as np
+    #from scipy.interpolate import griddata
     from sim.wave2d.wave2d import euler_zyz
-    from matplotlib import colors
+    #from matplotlib import colors
     
     # epi_lon = -10
     # epi_lat = 0
     
-    aia = sunpy.Map(sunpy.AIA_171_IMAGE).resample([500,500])
+    #aia = sunpy.Map(sunpy.AIA_171_IMAGE).resample([500,500])
     # tmap = util.map_hpc_to_hg(aia)
     # tmap.show()
     
-    map = aia
+    #map = aia
     
     x, y = wcs.convert_pixel_to_data(map.header)
     
@@ -161,7 +161,7 @@ def map_hpc_to_hg_rotate(map, epi_lon = 0, epi_lat = 0, xbin = 1, ybin = 1):
     
     newdata = griddata(points, values, newgrid, method="cubic")
     
-    header = map.header
+    header = map.header.copy()
     header['CDELT1'] = lon_bin
     header['NAXIS1'] = len(lon)
     header['CRVAL1'] = lon.min()
@@ -184,6 +184,6 @@ def map_hpc_to_hg_rotate(map, epi_lon = 0, epi_lat = 0, xbin = 1, ybin = 1):
         "x": wcs.get_center(header, axis='x'),
         "y": wcs.get_center(header, axis='y')}
     
-    transformed_map.show(norm = colors.Normalize(0,1000))
+    #transformed_map.show(norm = colors.Normalize(0,1000))
     
     return transformed_map


### PR DESCRIPTION
Be careful with assignment statements and objects!  If you intend to copy the object, do so explicitly!

sim.wave2d can now throw in some structured noise, although this is turned off by default in the example script because the implementation is rather slow.  The example script also has commented-out lines showing how util can be used on the simulated data.  Note that, compared to working with the raw simulated data in HG' coordinates, the extra steps of transforming from HG' to HPC and back to HG' add on quite a bit of time (especially because util is coded for cubic interpolation).
