### PR TITLE
Fixes sim.wave2d and visualize

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -20,7 +20,7 @@ def visualize(wave_maps, delay = 0.1, range = None):
     axes.set_title("%s %s" % (wave_maps[0].name, wave_maps[0].date))
     params = {
         "cmap": wave_maps[0].cmap,
-        "norm": wave_maps[0].norm()
+        "norm": wave_maps[0].norm
     }
     if range != None:
         params["norm"] = colors.Normalize(range[0],range[1])


### PR DESCRIPTION
`sim.wave2d` and `visualize` now work again, so that should help figuring out how to fix the rest of the code.  Merging immediately

As a gripe, @wafels did a bad thing back in 2012 and added carriage returns to all of the lines in `wave2d.py` in commit @db4f9fb.  I'm reluctant to change it back because it will obscure the git history (again).
